### PR TITLE
Fix SDRAM size in linker scripts.  It's 16MBytes (128Mbits).

### DIFF
--- a/STM32F469NIHX_FLASH.ld
+++ b/STM32F469NIHX_FLASH.ld
@@ -48,7 +48,7 @@ MEMORY
   CCMRAM    (xrw)    : ORIGIN = 0x10000000,   LENGTH = 64K
   RAM    (xrw)    : ORIGIN = 0x20000000,   LENGTH = 320K
   FLASH    (rx)    : ORIGIN = 0x8000000,   LENGTH = 2048K
-  SDRAM    (rw)	   : ORIGIN = 0xC0000000,  LENGTH = 128M
+  SDRAM    (rw)	   : ORIGIN = 0xC0000000,  LENGTH = 16M
 }
 
 /* Sections */

--- a/STM32F469NIHX_RAM.ld
+++ b/STM32F469NIHX_RAM.ld
@@ -48,7 +48,7 @@ MEMORY
   CCMRAM    (xrw)    : ORIGIN = 0x10000000,   LENGTH = 64K
   RAM    (xrw)    : ORIGIN = 0x20000000,   LENGTH = 320K
   FLASH    (rx)    : ORIGIN = 0x8000000,   LENGTH = 2048K
-  SDRAM    (rw)	   : ORIGIN = 0xC0000000,  LENGTH = 128M
+  SDRAM    (rw)	   : ORIGIN = 0xC0000000,  LENGTH = 16M
 }
 
 /* Sections */


### PR DESCRIPTION
This fixes lvgl/lv_port_stm32f469_disco#12.
